### PR TITLE
chore: update locker size translations and improve reservation deleti…

### DIFF
--- a/composeApp/src/androidMain/kotlin/org/perso/bikerbox/data/repository/firebase/FirebaseLockersRepository.kt
+++ b/composeApp/src/androidMain/kotlin/org/perso/bikerbox/data/repository/firebase/FirebaseLockersRepository.kt
@@ -340,12 +340,7 @@ class FirebaseLockersRepository : LockersRepository {
                 throw SecurityException("Cette réservation n'appartient pas à l'utilisateur courant")
             }
 
-            val updates = hashMapOf<String, Any>(
-                "status" to "CANCELLED",
-                "cancelledAt" to FieldValue.serverTimestamp()
-            )
-
-            reservationsCollection.document(reservationId).update(updates).await()
+            reservationsCollection.document(reservationId).delete().await()
         } catch (e: Exception) {
             e.printStackTrace()
             throw e

--- a/composeApp/src/commonMain/kotlin/org/perso/bikerbox/data/models/LockerSizeExt.kt
+++ b/composeApp/src/commonMain/kotlin/org/perso/bikerbox/data/models/LockerSizeExt.kt
@@ -2,9 +2,9 @@ package org.perso.bikerbox.data.models
 
 val LockerSize.displayName: String
     get() = when(this) {
-        LockerSize.SMALL -> "Simple"
+        LockerSize.SMALL -> "Small"
         LockerSize.MEDIUM -> "Double"
-        LockerSize.LARGE -> "Très grand"
+        LockerSize.LARGE -> "Large"
     }
 
 val LockerSize.basePricePerDay: Double
@@ -12,10 +12,4 @@ val LockerSize.basePricePerDay: Double
         LockerSize.SMALL -> 6.0
         LockerSize.MEDIUM -> 10.0
         LockerSize.LARGE -> 14.0
-    }
-val LockerSize.hourlyRate: Double
-    get() = when(this) {
-        LockerSize.SMALL -> 6.0 / 24
-        LockerSize.MEDIUM -> 10.0 / 24
-        LockerSize.LARGE -> 14.0 / 24
     }


### PR DESCRIPTION
…on logic

- Translated locker size names in `LockerSizeExt.kt` to English for consistency (`Simple` -> `Small`, `Très grand` -> `Large`).
- Replaced reservation status update logic with direct deletion in `FirebaseLockersRepository` for simplification and cleaner code execution.