### PR TITLE
chore: migrate to MapLibre and improve map UI with multiple styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## ⚠️ Project Status: Active Development
 This project is currently under development and not yet finalized. Some features may be incomplete or subject to change.
-Current version: Alpha 0.4
+Current version: Alpha 0.5
 
 ## About
 BikerBox is a personal mobile application project under development, designed for bikers. This application is a prototype/technical demonstrator developed for learning purposes and experimentation with Kotlin Multiplatform and Jetpack Compose. It simulates a secure locker management system allowing bikers to store their equipment (helmets, jackets, etc.).
@@ -14,11 +14,12 @@ BikerBox is a personal mobile application project under development, designed fo
 
 ## 🌟 Features
 
-### Recently Implemented in v0.4 ✅
-- **Map Integration**: Integrated Google Maps to display station locations.
-- **Real-Time Station Markers**: Added real-time display of BikerBox station markers on the map, fetched directly from Firebase.
-- **Location Permissions**: Configured necessary location permissions (`ACCESS_FINE_LOCATION`, `ACCESS_COARSE_LOCATION`) for geolocation features.
-- **Expanded Localization**: Added new string resources for map and permission features, maintaining a fully sorted and organized file structure.
+### Recently Implemented in v0.5 ✅
+- **OpenStreetMap Integration**: Migrated from Google Maps to MapLibre/OpenStreetMap for better open-source compliance and flexibility.
+- **Multiple Map Styles**: Added support for multiple map styles (Standard, Dark, Light, Minimal, Detailed) with seamless switching.
+- **Enhanced Map UI**: Improved map interface with style selector and better performance optimization.
+- **Dependency Optimization**: Removed Google Maps dependency and integrated lightweight MapLibre solution.
+- **Improved Architecture**: Enhanced Firebase initialization with lazy loading and better resource management.
 
 ### Core Features ✅
 - Authentication system
@@ -37,6 +38,9 @@ BikerBox is a personal mobile application project under development, designed fo
 - Performance optimizations
 
 ### Planned 📋
+- **Map filters by distance and availability**
+- **GPS navigation to nearest station**
+- **Traffic indicators and estimated travel time**
 - Offline mode
 - Administrator interface
 - Advanced analytics
@@ -60,34 +64,21 @@ BikerBox is a personal mobile application project under development, designed fo
 
 bash git clone [https://github.com/votre-username/BikerBox.git](https://github.com/votre-username/BikerBox.git) cd BikerBox
 
-### 2. Configure API Keys and Services
+### 2. Configure Firebase
+1. **Firebase**:
+    - Create a project in the [Firebase Console](https://console.firebase.google.com/).
+    - Add an Android application with the package name `org.perso.bikerbox`.
+    - Download the `google-services.json` file and place it in the `composeApp/` directory.
+    - Enable **Authentication** (Email/Password) and the **Firestore Database**.
 
-1.  **Firebase**:
-    *   Create a project in the [Firebase Console](https://console.firebase.google.com/).
-    *   Add an Android application with the package name `org.perso.bikerbox`.
-    *   Download the `google-services.json` file and place it in the `composeApp/` directory.
-    *   Enable **Authentication** (Email/Password) and the **Firestore Database**.
-
-2.  **Google Maps**:
-    *   In the [Google Cloud Console](https://console.cloud.google.com/), ensure the **Maps SDK for Android** is enabled for your project.
-    *   Get your **Google Maps API Key**.
-
-### 3. Configure Local Properties
-
-1.  Open the `local.properties` file at the project root (create it if it doesn't exist).
-2.  Add your Google Maps API key to this file. **This file is ignored by Git and keeps your key secure.**
-
-    ```properties
-    # local.properties (This file should NOT be committed to Git)
-    MAPS_API_KEY="YOUR_GOOGLE_MAPS_API_KEY_HERE"
-    ```
-
-3.  Sync the project with Gradle in Android Studio.
+2. Sync the project with Gradle in Android Studio.
 
 ## ⚡ Known Issues
 - The application may be unstable on certain devices.
 - Some features are simulated or partially implemented.
 - Performance may not be optimal during the development phase.
+- Map style switching may require brief loading time.
+- OpenStreetMap tiles loading depends on internet connection quality.
 
 ## 🚀 Build and Run
 ### Android
@@ -108,10 +99,11 @@ This personal project follows the MVVM (Model-View-ViewModel) architecture and i
 - **utils**: Utilities and extensions
 
 ## 🛠 Technologies Used
-- **Kotlin Multiplatform 2.2.0** - For code sharing between platforms
+- - **Kotlin Multiplatform 2.2.0** - For code sharing between platforms
 - **Compose Multiplatform 1.8.2** - For user interface
 - **Firebase** - For authentication and real-time database
-- **Google Maps SDK for Android** - For map display and interaction
+- **MapLibre Android SDK 11.0.0** - For map display and interaction
+- **OpenStreetMap** - For map data and tiles
 - **Koin** - For dependency injection
 - **Kotlin Coroutines & Flow** - For asynchronous programming
 - **Lifecycle 2.9.1** - For lifecycle management
@@ -134,6 +126,7 @@ Supports multiple payment methods with visual branding:
 - PayPal
 
 ## 📈 Recent Updates
+- **v0.5**: Migrated to OpenStreetMap/MapLibre, added multiple map styles, improved open-source compliance and performance.
 - **v0.4**: Integrated Google Maps with real-time station markers, configured location permissions, and expanded localization resources.
 - **v0.3**: Complete French localization, localized date formatting, enhanced locker size system, code cleanup and optimization.
 - **v0.2**: Complete UI localization, enhanced payment flow, improved reservation system.

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
     alias(libs.plugins.androidApplication)
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.composeCompiler)
-    id ("com.google.gms.google-services")
+    id("com.google.gms.google-services")
 }
 
 kotlin {
@@ -47,7 +47,7 @@ kotlin {
         androidMain.dependencies {
             implementation(compose.preview)
             implementation(libs.androidx.activity.compose)
-            implementation(libs.maps.compose)
+            implementation("org.maplibre.gl:android-sdk:11.0.0")
 
 
             api(project.dependencies.platform("com.google.firebase:firebase-bom:32.7.0"))
@@ -107,9 +107,6 @@ android {
         versionCode = 1
         versionName = "1.0"
 
-        val mapsApiKey = localProperties.getProperty("MAPS_API_KEY") ?: ""
-
-        manifestPlaceholders["MAPS_API_KEY"] = mapsApiKey
     }
 
     packaging {
@@ -138,6 +135,7 @@ dependencies {
     implementation(libs.androidx.navigation.runtime.android)
     implementation(libs.androidx.constraintlayout)
     debugImplementation(compose.uiTooling)
+    implementation("org.maplibre.gl:android-plugin-annotation-v9:3.0.0")
 
     implementation ("io.coil-kt:coil-compose:2.5.0")
 }

--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -13,10 +13,6 @@
         android:name=".BikerBoxApplication"
         android:theme="@android:style/Theme.Material.Light.NoActionBar">
 
-        <meta-data
-                android:name="com.google.android.geo.API_KEY"
-                android:value="${MAPS_API_KEY}"/>
-
         <activity
             android:exported="true"
             android:configChanges="orientation|screenSize|screenLayout|keyboardHidden|mnc|colorMode|density|fontScale|fontWeightAdjustment|keyboard|layoutDirection|locale|mcc|navigation|smallestScreenSize|touchscreen|uiMode"

--- a/composeApp/src/androidMain/kotlin/org/perso/bikerbox/BikerBoxApplication.kt
+++ b/composeApp/src/androidMain/kotlin/org/perso/bikerbox/BikerBoxApplication.kt
@@ -1,22 +1,32 @@
 package org.perso.bikerbox
 
 import android.app.Application
-import android.util.Log
 import com.google.firebase.FirebaseApp
+import org.maplibre.android.MapLibre
 import org.perso.bikerbox.data.location.LocationProvider
+import org.perso.bikerbox.data.repository.AuthRepository
+import org.perso.bikerbox.data.repository.LockersProvider
+import org.perso.bikerbox.data.repository.firebase.FirebaseAuthRepository
+import org.perso.bikerbox.data.repository.firebase.FirebaseLockersRepository
 
 class BikerBoxApplication : Application() {
     val locationProvider: LocationProvider by lazy {
         LocationProvider(this)
     }
 
+    lateinit var authRepository: AuthRepository
+        private set
+
     override fun onCreate() {
         super.onCreate()
-        try {
-            FirebaseApp.initializeApp(this)
-            Log.d("BikerBoxApplication", "Firebase initialisé")
-        } catch (e: Exception) {
-            Log.e("BikerBoxApplication", "Erreur lors de l'initialisation de Firebase: ${e.message}")
-        }
+        // 1. Initialiser Firebase
+        FirebaseApp.initializeApp(this)
+
+        // 2. Initialiser nos Repositories qui dépendent de Firebase
+        authRepository = FirebaseAuthRepository()
+        LockersProvider.initialize(FirebaseLockersRepository())
+
+        // 3. Initialiser MapLibre
+        MapLibre.getInstance(this)
     }
 }

--- a/composeApp/src/androidMain/kotlin/org/perso/bikerbox/data/repository/firebase/FirebaseAuthRepository.kt
+++ b/composeApp/src/androidMain/kotlin/org/perso/bikerbox/data/repository/firebase/FirebaseAuthRepository.kt
@@ -1,6 +1,6 @@
 package org.perso.bikerbox.data.repository.firebase
 
-import android.net.Uri
+import androidx.core.net.toUri
 import com.google.firebase.Firebase
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
@@ -8,18 +8,17 @@ import com.google.firebase.auth.UserProfileChangeRequest
 import com.google.firebase.auth.auth
 import com.google.firebase.firestore.firestore
 import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.tasks.await
-import kotlinx.coroutines.flow.Flow
 import org.perso.bikerbox.data.models.Resource
 import org.perso.bikerbox.data.models.User
 import org.perso.bikerbox.data.repository.AuthRepository
-import androidx.core.net.toUri
 
 class FirebaseAuthRepository : AuthRepository {
-    private val auth = Firebase.auth
-    private val firestore = Firebase.firestore
-    private val usersCollection = firestore.collection("users")
+    private val auth by lazy { Firebase.auth }
+    private val firestore by lazy { Firebase.firestore }
+    private val usersCollection by lazy { firestore.collection("users") }
 
 
 

--- a/composeApp/src/androidMain/kotlin/org/perso/bikerbox/data/repository/firebase/FirebaseLockersRepository.kt
+++ b/composeApp/src/androidMain/kotlin/org/perso/bikerbox/data/repository/firebase/FirebaseLockersRepository.kt
@@ -17,10 +17,11 @@ import java.time.ZoneId
 import java.util.*
 
 class FirebaseLockersRepository : LockersRepository {
-    private val firestore = FirebaseFirestore.getInstance()
-    private val auth = FirebaseAuth.getInstance()
-    private val lockersCollection = firestore.collection("lockers")
-    private val reservationsCollection = firestore.collection("reservations")
+    private val firestore by lazy { FirebaseFirestore.getInstance() }
+    private val auth by lazy { FirebaseAuth.getInstance() }
+    private val lockersCollection by lazy { firestore.collection("lockers") }
+    private val reservationsCollection by lazy { firestore.collection("reservations") }
+
 
     override suspend fun getAvailableLockers(): List<Locker> {
         return try {

--- a/composeApp/src/commonMain/composeResources/values-fr/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-fr/strings.xml
@@ -18,8 +18,10 @@
     <string name="Cancel">Annuler</string>
     <string name="Cardholder_Name">Nom du titulaire</string>
     <string name="Card_number">Numéro de carte</string>
+    <string name="Change_map_style">Changer le style de carte</string>
     <string name="Choose">Choisir</string>
     <string name="Choose_a_date">Choisir une date</string>
+    <string name="Close">Fermer</string>
     <string name="Code">Code</string>
     <string name="Confirm">Confirmer</string>
     <string name="Confirm_Cancellation">Confirmer l'annulation</string>
@@ -67,6 +69,7 @@
     <string name="Loading_reservation_details">Chargement des détails de la réservation...</string>
     <string name="Loading_your_reservations">Chargement de vos réservations...</string>
     <string name="Location_access">Accès à la localisation</string>
+    <string name="Location_in_progress">Localisation en cours...</string>
     <string name="Location_denied_permanently">Localisation refusée</string>
     <string name="Location_permission_denied_message">La permission de localisation a été refusée de manière permanente. Vous pouvez l'activer dans les paramètres de l'application.</string>
     <string name="Location_permission_explanation">Pour vous montrer les stations BikerBox à proximité, veuillez autoriser l'accès à votre localisation.</string>
@@ -82,6 +85,7 @@
     <string name="Log_out">Se déconnecter</string>
     <string name="march">mars</string>
     <string name="Map">Carte</string>
+    <string name="Map_style">Style de carte</string>
     <string name="may">mai</string>
     <string name="Medium">Moyen</string>
     <string name="Method">Méthode</string>
@@ -98,6 +102,11 @@
     <string name="one_helmet_and_one_coat">1 casque + 1 manteau</string>
     <string name="Other_methods">Autres méthodes</string>
     <string name="Open_settings">Ouvrir les paramètres</string>
+    <string name="openstreetmap_style_url_standard">https://demotiles.maplibre.org/style.json</string>
+    <string name="openstreetmap_style_url_sombre">https://tiles.openfreemap.org/styles/dark</string>
+    <string name="openstreetmap_style_url_clair">https://tiles.openfreemap.org/styles/bright</string>
+    <string name="openstreetmap_style_url_minimal">https://tiles.openfreemap.org/styles/positron</string>
+    <string name="openstreetmap_style_url_detaille">https://tiles.openfreemap.org/styles/liberty</string>
     <string name="Password">Mot de passe</string>
     <string name="Password_Reset">Réinitialisation du mot de passe</string>
     <string name="Passwords_do_not_match">Les mots de passe ne correspondent pas</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -18,8 +18,10 @@
     <string name="Cancel">Cancel</string>
     <string name="Cardholder_Name">Cardholder Name</string>
     <string name="Card_number">Card Number</string>
+    <string name="Change_map_style">Change map style</string>
     <string name="Choose">Choose</string>
     <string name="Choose_a_date">Choose a date</string>
+    <string name="Close">Close</string>
     <string name="Code">Code</string>
     <string name="Confirm">Confirm</string>
     <string name="Confirm_Cancellation">Confirm Cancellation</string>
@@ -63,6 +65,7 @@
     <string name="Large">Large</string>
     <string name="List">List</string>
     <string name="Loading">Loading</string>
+    <string name="Location_in_progress">Location in progress...</string>
     <string name="Loading_longer">Loading longer than expected?</string>
     <string name="Loading_reservation_details">Loading reservation details...</string>
     <string name="Loading_your_reservations">Loading your reservations...</string>
@@ -82,6 +85,7 @@
     <string name="Log_out">Log out</string>
     <string name="march">March</string>
     <string name="Map">Map</string>
+    <string name="Map_style">Map style</string>
     <string name="may">May</string>
     <string name="Medium">Medium</string>
     <string name="Method">Method</string>
@@ -98,6 +102,11 @@
     <string name="one_helmet_and_one_coat">1 helmet + 1 coat</string>
     <string name="Other_methods">Other methods</string>
     <string name="Open_settings">Open Settings</string>
+    <string name="openstreetmap_style_url_standard">https://demotiles.maplibre.org/style.json</string>
+    <string name="openstreetmap_style_url_sombre">https://tiles.openfreemap.org/styles/dark</string>
+    <string name="openstreetmap_style_url_clair">https://tiles.openfreemap.org/styles/bright</string>
+    <string name="openstreetmap_style_url_minimal">https://tiles.openfreemap.org/styles/positron</string>
+    <string name="openstreetmap_style_url_detaille">https://tiles.openfreemap.org/styles/liberty</string>
     <string name="Password">Password</string>
     <string name="Password_Reset">Password Reset</string>
     <string name="Passwords_do_not_match">Passwords do not match</string>
@@ -113,6 +122,7 @@
     <string name="Price_small">6€/day</string>
     <string name="Proceed_to_payment">Proceed to payment</string>
     <string name="Processing_payment">Processing payment...</string>
+    <string name="Profile">Profil</string>
     <string name="Profile_successfully_updated">Profile successfully updated</string>
     <string name="Rationale_message">Location access is needed to show stations on the map. Without it, we can\'t help you find a locker.</string>
     <string name="Refresh">Refresh</string>

--- a/composeApp/src/commonMain/kotlin/org/perso/bikerbox/ui/components/LockerDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/perso/bikerbox/ui/components/LockerDetailsScreen.kt
@@ -1,10 +1,9 @@
-package org.perso.bikerbox.ui.screens
+package org.perso.bikerbox.ui.components
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import org.perso.bikerbox.data.models.Locker

--- a/composeApp/src/commonMain/kotlin/org/perso/bikerbox/ui/screens/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/perso/bikerbox/ui/screens/HomeScreen.kt
@@ -1,34 +1,54 @@
 package org.perso.bikerbox.ui.screens
 
 import android.Manifest
+import android.content.pm.PackageManager
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.Rect
+import android.os.Bundle
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ExitToApp
 import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import bikerbox.composeapp.generated.resources.*
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
-import com.google.accompanist.permissions.isGranted
-import com.google.accompanist.permissions.rememberPermissionState
-import com.google.android.gms.maps.CameraUpdateFactory
-import com.google.android.gms.maps.model.CameraPosition
-import com.google.android.gms.maps.model.LatLng
-import com.google.maps.android.compose.*
 import org.jetbrains.compose.resources.stringResource
+import org.maplibre.android.location.LocationComponent
+import org.maplibre.android.location.LocationComponentActivationOptions
+import org.maplibre.android.location.modes.CameraMode
+import org.maplibre.android.location.modes.RenderMode
+import org.maplibre.android.maps.MapLibreMap
+import org.maplibre.android.maps.MapView
 import org.perso.bikerbox.data.models.Locker
 import org.perso.bikerbox.data.models.Resource
+import org.perso.bikerbox.ui.components.LockerDetailsBottomSheet
 import org.perso.bikerbox.ui.viewmodel.AuthViewModel
 import org.perso.bikerbox.ui.viewmodel.ReservationState
 import org.perso.bikerbox.ui.viewmodel.ReservationViewModel
+import androidx.core.graphics.createBitmap
+import androidx.core.graphics.toColorInt
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -57,7 +77,7 @@ fun HomeScreen(
                     }
                     Box {
                         IconButton(onClick = { showMenu = true }) {
-                            Icon(Icons.Default.AccountCircle, contentDescription = "Profil")
+                            Icon(Icons.Default.AccountCircle, contentDescription = stringResource(Res.string.Profile))
                         }
                         DropdownMenu(
                             expanded = showMenu,
@@ -166,54 +186,311 @@ private fun LockerMap(
     lockers: List<Locker>,
     viewModel: ReservationViewModel
 ) {
-    val locationPermissionState = rememberPermissionState(Manifest.permission.ACCESS_FINE_LOCATION)
-    if (locationPermissionState.status.isGranted) {
-        LaunchedEffect(Unit) { viewModel.startLocationUpdates() }
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val userLocation by viewModel.userLocation.collectAsState()
+
+    LaunchedEffect(Unit) {
+        viewModel.startLocationUpdates()
     }
 
-    if (locationPermissionState.status.isGranted) {
-        val userLocation by viewModel.userLocation.collectAsState()
-        val cameraPositionState = rememberCameraPositionState { position = CameraPosition.fromLatLngZoom(LatLng(48.8566, 2.3522), 10f) }
-        var hasCenteredOnUser by remember { mutableStateOf(false) }
+    var selectedStyleIndex by remember { mutableIntStateOf(0) }
+    val mapStyles = listOf(
+        "Détaillé" to stringResource(Res.string.openstreetmap_style_url_detaille),
+        "Standard" to stringResource(Res.string.openstreetmap_style_url_standard),
+        "Sombre" to stringResource(Res.string.openstreetmap_style_url_sombre),
+        "Clair" to stringResource(Res.string.openstreetmap_style_url_clair),
+        "Minimal" to stringResource(Res.string.openstreetmap_style_url_minimal),
+    )
 
-        LaunchedEffect(userLocation) {
-            if (userLocation != null && !hasCenteredOnUser) {
-                val userLatLng = LatLng(userLocation!!.latitude, userLocation!!.longitude)
-                cameraPositionState.animate(update = CameraUpdateFactory.newLatLngZoom(userLatLng, 15f), durationMs = 1500)
-                hasCenteredOnUser = true
+    var showStyleSelector by remember { mutableStateOf(false) }
+    var mapLibreMap by remember { mutableStateOf<MapLibreMap?>(null) }
+    var locationComponent by remember { mutableStateOf<LocationComponent?>(null) }
+
+    val mapView = remember {
+        MapView(context)
+    }
+
+    // Fonction pour vérifier les permissions
+    fun hasLocationPermission(): Boolean {
+        return ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.ACCESS_FINE_LOCATION
+        ) == PackageManager.PERMISSION_GRANTED ||
+                ContextCompat.checkSelfPermission(
+                    context,
+                    Manifest.permission.ACCESS_COARSE_LOCATION
+                ) == PackageManager.PERMISSION_GRANTED
+    }
+
+    // Fonction pour configurer le composant de localisation
+    fun configureLocationComponent(locationComp: LocationComponent) {
+        if (hasLocationPermission()) {
+            try {
+                locationComp.isLocationComponentEnabled = true
+                locationComp.cameraMode = CameraMode.TRACKING
+                locationComp.renderMode = RenderMode.COMPASS
+            } catch (e: SecurityException) {
+                // Gestion d'erreur si les permissions sont révoquées
+                locationComp.isLocationComponentEnabled = false
+            }
+        } else {
+            locationComp.isLocationComponentEnabled = false
+        }
+    }
+
+    DisposableEffect(lifecycleOwner) {
+        val lifecycle = lifecycleOwner.lifecycle
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_CREATE -> mapView.onCreate(Bundle())
+                Lifecycle.Event.ON_START -> mapView.onStart()
+                Lifecycle.Event.ON_RESUME -> mapView.onResume()
+                Lifecycle.Event.ON_PAUSE -> mapView.onPause()
+                Lifecycle.Event.ON_STOP -> mapView.onStop()
+                Lifecycle.Event.ON_DESTROY -> mapView.onDestroy()
+                else -> {}
+            }
+        }
+        lifecycle.addObserver(observer)
+        onDispose {
+            lifecycle.removeObserver(observer)
+        }
+    }
+
+    LaunchedEffect(selectedStyleIndex) {
+        mapLibreMap?.setStyle(mapStyles[selectedStyleIndex].second)
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        if (userLocation == null) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .padding(16.dp)
+                    .background(
+                        Color.Black.copy(alpha = 0.7f),
+                        RoundedCornerShape(8.dp)
+                    )
+                    .padding(12.dp)
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(16.dp),
+                        strokeWidth = 2.dp,
+                        color = Color.White
+                    )
+                    Text(
+                        text = stringResource(Res.string.Location_in_progress),
+                        color = Color.White,
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                }
             }
         }
 
-        val mapProperties = MapProperties(isMyLocationEnabled = true)
+        AndroidView(
+            factory = { _ ->
+                mapView.apply {
+                    getMapAsync { map ->
+                        mapLibreMap = map
+                        map.setStyle(mapStyles[selectedStyleIndex].second) { style ->
+                            val lockerBitmap = createLockerIcon(context)
+                            style.addImage("locker-icon", lockerBitmap)
 
-        GoogleMap(modifier = Modifier.fillMaxSize(), cameraPositionState = cameraPositionState, properties = mapProperties) {
-            lockers.forEach { locker ->
-                Marker(
-                    state = rememberMarkerState(position = LatLng(locker.latitude, locker.longitude)),
-                    title = locker.name,
-                    snippet = "Cliquez pour voir les détails",
-                    onClick = {
-                        viewModel.selectLocker(locker)
-                        true
+                            locationComponent = map.locationComponent.apply {
+                                activateLocationComponent(
+                                    LocationComponentActivationOptions
+                                        .builder(context, style)
+                                        .build()
+                                )
+                                // Utiliser la fonction locale pour configurer
+                                configureLocationComponent(this)
+                            }
+
+                            map.addOnMapClickListener { point ->
+                                val features = map.queryRenderedFeatures(
+                                    map.projection.toScreenLocation(point),
+                                    "locker-layer"
+                                )
+
+                                if (features.isNotEmpty()) {
+                                    val feature = features[0]
+                                    val lockerName = feature.getStringProperty("name")
+
+                                    val selectedLocker = lockers.find { it.name == lockerName }
+                                    selectedLocker?.let {
+                                        viewModel.selectLocker(it)
+                                    }
+                                }
+                                true
+                            }
+                        }
+
+                        map.uiSettings.apply {
+                            isCompassEnabled = true
+                            isRotateGesturesEnabled = true
+                            isTiltGesturesEnabled = false
+                            isAttributionEnabled = true
+                            isLogoEnabled = true
+                        }
                     }
-                )
-            }
-        }
-    } else {
-        Column(
-            modifier = Modifier.fillMaxSize().padding(16.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center
+                }
+            },
+            update = { view ->
+                view.getMapAsync { map ->
+                    map.getStyle { style ->
+                        map.clear()
+
+                        lockers.forEach { locker ->
+                            val markerOptions = org.maplibre.android.annotations.MarkerOptions()
+                                .position(org.maplibre.android.geometry.LatLng(locker.latitude, locker.longitude))
+                                .title(locker.name)
+                                .snippet(locker.location)
+
+                            val marker = map.addMarker(markerOptions)
+                        }
+
+                        map.setOnMarkerClickListener { marker ->
+                            val clickedLocker = lockers.find { locker ->
+                                locker.latitude == marker.position.latitude &&
+                                        locker.longitude == marker.position.longitude
+                            }
+
+                            clickedLocker?.let { locker ->
+                                viewModel.selectLocker(locker)
+                            }
+
+                            true
+                        }
+
+                        userLocation?.let { location ->
+                            map.animateCamera(
+                                org.maplibre.android.camera.CameraUpdateFactory.newLatLngZoom(
+                                    org.maplibre.android.geometry.LatLng(location.latitude, location.longitude),
+                                    15.0
+                                )
+                            )
+                        } ?: run {
+                            if (lockers.isNotEmpty()) {
+                                val firstLocker = lockers.first()
+                                map.animateCamera(
+                                    org.maplibre.android.camera.CameraUpdateFactory.newLatLngZoom(
+                                        org.maplibre.android.geometry.LatLng(firstLocker.latitude, firstLocker.longitude),
+                                        12.0
+                                    )
+                                )
+                            }
+                        }
+                    }
+                }
+            },
+            modifier = Modifier.fillMaxSize()
+        )
+
+        FloatingActionButton(
+            onClick = { showStyleSelector = true },
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                .padding(16.dp)
         ) {
-            Text(stringResource(Res.string.Location_permission_required))
-            Spacer(modifier = Modifier.height(8.dp))
-            Text(stringResource(Res.string.Location_permission_explanation))
-            Spacer(modifier = Modifier.height(16.dp))
-            Button(onClick = { locationPermissionState.launchPermissionRequest() }) {
-                Text(stringResource(Res.string.Grant_permission))
+            Icon(Icons.Default.Settings, contentDescription = stringResource(Res.string.Change_map_style))
+        }
+
+        if (showStyleSelector) {
+            Card(
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .padding(16.dp)
+                    .fillMaxWidth()
+            ) {
+                Column(
+                    modifier = Modifier.padding(16.dp)
+                ) {
+                    Text(
+                        text = stringResource(Res.string.Map_style),
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold
+                    )
+
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    mapStyles.forEachIndexed { index, (name, _) ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable {
+                                    selectedStyleIndex = index
+                                    showStyleSelector = false
+                                }
+                                .padding(vertical = 8.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            RadioButton(
+                                selected = selectedStyleIndex == index,
+                                onClick = {
+                                    selectedStyleIndex = index
+                                    showStyleSelector = false
+                                }
+                            )
+                            Text(
+                                text = name,
+                                modifier = Modifier.padding(start = 8.dp)
+                            )
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    Button(
+                        onClick = { showStyleSelector = false },
+                        modifier = Modifier.align(Alignment.End)
+                    ) {
+                        Text(stringResource(Res.string.Close))
+                    }
+                }
             }
         }
     }
+}
+
+private fun createLockerIcon(context: android.content.Context): Bitmap {
+    val size = 48
+    val bitmap = createBitmap(size, size)
+    val canvas = Canvas(bitmap)
+
+    val paint = Paint().apply {
+        isAntiAlias = true
+        color = "#FF4444".toColorInt()
+        style = Paint.Style.FILL
+    }
+
+    val radius = size / 2f - 2f
+    canvas.drawCircle(size / 2f, size / 2f, radius, paint)
+
+    paint.apply {
+        color = android.graphics.Color.WHITE
+        style = Paint.Style.STROKE
+        strokeWidth = 2f
+    }
+    canvas.drawCircle(size / 2f, size / 2f, radius, paint)
+
+    paint.apply {
+        color = android.graphics.Color.WHITE
+        style = Paint.Style.FILL
+        textSize = 20f
+        textAlign = Paint.Align.CENTER
+    }
+
+    val lockSymbol = "🔒"
+    val bounds = Rect()
+    paint.getTextBounds(lockSymbol, 0, lockSymbol.length, bounds)
+    canvas.drawText(lockSymbol, size / 2f, size / 2f + bounds.height() / 2f, paint)
+
+    return bitmap
 }
 
 @Composable
@@ -222,7 +499,7 @@ private fun LoadingState() {
         Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.Center) {
             CircularProgressIndicator()
             Spacer(modifier = Modifier.height(16.dp))
-            Text("Loading...")
+            Text(stringResource(Res.string.Loading))
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/perso/bikerbox/ui/screens/MyReservationScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/perso/bikerbox/ui/screens/MyReservationScreen.kt
@@ -179,7 +179,7 @@ fun ReservationCard(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(
-                    text = "${stringResource(Res.string.Locker)} #${reservation.lockerId}",
+                    text = "${stringResource(Res.string.Locker)} ${reservation.lockerName}",
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.Bold
                 )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,8 +19,6 @@ navigationComposeAndroid = "2.9.1"
 navigationRuntimeAndroid = "2.9.1"
 playServicesLocation = "21.3.0"
 accompanistPermissions = "0.37.3"
-playServicesMaps = "19.2.0"
-maps-compose = "6.6.0"
 
 [libraries]
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "androidx-constraintlayout" }
@@ -37,8 +35,6 @@ androidx-navigation-compose-android = { group = "androidx.navigation", name = "n
 androidx-navigation-runtime-android = { group = "androidx.navigation", name = "navigation-runtime-android", version.ref = "navigationRuntimeAndroid" }
 play-services-location = { group = "com.google.android.gms", name = "play-services-location", version.ref = "playServicesLocation" }
 accompanist-permissions = { group = "com.google.accompanist", name = "accompanist-permissions", version.ref = "accompanistPermissions" }
-play-services-maps = { group = "com.google.android.gms", name = "play-services-maps", version.ref = "playServicesMaps" }
-maps-compose = { group = "com.google.maps.android", name = "maps-compose", version.ref = "maps-compose" }
 
 [bundles]
 


### PR DESCRIPTION
- Replaced Google Maps with MapLibre for open-source compliance and better flexibility.
- Added support for multiple map styles with seamless toggling functionality.
- Refactored Firebase initialization and introduced lazy loading for improved resource management.
- Cleaned `strings.xml`, adding new entries for map settings and notifications.
- Updated README for v0.5, documenting the migration, architectural improvements, and map feature enhancements.
- Optimized `FirebaseLockersRepository` with lazy initialization of key components.
- Adjusted map marker logic for interactive locker selection and detail display.